### PR TITLE
Remove src folder from ignore list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,6 @@
         "gruntfile.js",
         "karma.conf.js",
         "*.yml",
-        "src",
         "lib",
         "example",
         "test"


### PR DESCRIPTION
This is to enable users to include only specific tool from the tool belt
